### PR TITLE
Fixed validation of AutoYaST profile (bsc#805275).

### DIFF
--- a/src/autoyast-rnc/audit-laf.rnc
+++ b/src/autoyast-rnc/audit-laf.rnc
@@ -25,7 +25,10 @@ audit-laf = element audit-laf {
       element space_left        { text }? &
       element space_left_action { text }? &
       element tcp_client_max_idle { text }? &
-      element tcp_listen_queue    { text }?
+      element tcp_client_ports  { text }? &
+      element tcp_listen_port   { text }? &
+      element tcp_listen_queue  { text }? &
+      element tcp_max_per_addr  { text }?
     }? &
     element rules { text }?
 }


### PR DESCRIPTION
Added the elements that are in the default /etc/audit/auditd.conf from
audit-2.3.6.rpm