### PR TITLE
Fix AutoYaST schema in SLE 12 SP1

### DIFF
--- a/package/yast2-audit-laf.changes
+++ b/package/yast2-audit-laf.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Nov 18 12:52:22 UTC 2015 - mvidner@suse.com
+
+- Fix validation of AutoYaST profiles (bsc#954412)
+
+-------------------------------------------------------------------
 Thu Dec  4 09:49:17 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/src/autoyast-rnc/audit-laf.rnc
+++ b/src/autoyast-rnc/audit-laf.rnc
@@ -25,7 +25,10 @@ audit-laf = element audit-laf {
       element space_left        { text }? &
       element space_left_action { text }? &
       element tcp_client_max_idle { text }? &
-      element tcp_listen_queue    { text }?
+      element tcp_client_ports  { text }? &
+      element tcp_listen_port   { text }? &
+      element tcp_listen_queue  { text }? &
+      element tcp_max_per_addr  { text }?
     }? &
     element rules { text }?
 }


### PR DESCRIPTION
Fixes [bsc#954412](https://bugzilla.suse.com/show_bug.cgi?id=954412) for SLE 12 SP1. BTW, `SLE-12-GA` branch is merged into `sle-12-sp1-after_release`.