### PR TITLE
allow optional string and map types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-audit-laf-image yast-travis-ruby
+  - docker run -it --privileged -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-audit-laf-image yast-travis-ruby

--- a/package/yast2-audit-laf.changes
+++ b/package/yast2-audit-laf.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  7 13:02:36 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Autoyast schema: Allow optional types for string and map objects
+  (bsc#1170886)
+- 4.3.0
+
+-------------------------------------------------------------------
 Fri May 31 12:25:30 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-audit-laf.spec
+++ b/package/yast2-audit-laf.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-audit-laf
 Summary:        YaST2 - Configuration of Linux Auditing (LAF)
-Version:        4.2.0
+Version:        4.3.0
 Release:        0
 Url:            https://github.com/yast/yast-audit-laf
 Group:          System/YaST

--- a/src/autoyast-rnc/audit-laf.rnc
+++ b/src/autoyast-rnc/audit-laf.rnc
@@ -2,35 +2,42 @@ default namespace = "http://www.suse.com/1.0/yast2ns"
 namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
 namespace config = "http://www.suse.com/1.0/configns"
 
+include "common.rnc"
 
 audit-laf = element audit-laf {
-    element auditd {
-      element action_mail_acct { text }? &
-      element admin_space_left { text }? &
-      element admin_space_left_action { text }? &
-      element disk_error_action { text }? &
-      element disk_full_action  { text }? &
-      element disp_qos          { text }? &
-      element dispatcher        { text }? &
-      element flush             { text }? &
-      element freq              { text }? &
-      element log_file          { text }? &
-      element log_format        { text }? &
-      element log_group         { text }? &
-      element max_log_file      { text }? &
-      element max_log_file_action { text }? &
-      element name_format       { text }? &
-      element num_logs          { text }? &
-      element priority_boost    { text }? &
-      element space_left        { text }? &
-      element space_left_action { text }? &
-      element tcp_client_max_idle { text }? &
-      element tcp_client_ports  { text }? &
-      element tcp_listen_port   { text }? &
-      element tcp_listen_queue  { text }? &
-      element tcp_max_per_addr  { text }?
-    }? &
-    element rules { text }?
+    MAP,
+    (
+      element auditd {
+        MAP,
+        (
+          element action_mail_acct { STRING }? &
+          element admin_space_left { STRING }? &
+          element admin_space_left_action { STRING }? &
+          element disk_error_action { STRING }? &
+          element disk_full_action  { STRING }? &
+          element disp_qos          { STRING }? &
+          element dispatcher        { STRING }? &
+          element flush             { STRING }? &
+          element freq              { STRING }? &
+          element log_file          { STRING }? &
+          element log_format        { STRING }? &
+          element log_group         { STRING }? &
+          element max_log_file      { STRING }? &
+          element max_log_file_action { STRING }? &
+          element name_format       { STRING }? &
+          element num_logs          { STRING }? &
+          element priority_boost    { STRING }? &
+          element space_left        { STRING }? &
+          element space_left_action { STRING }? &
+          element tcp_client_max_idle { STRING }? &
+          element tcp_client_ports  { STRING }? &
+          element tcp_listen_port   { STRING }? &
+          element tcp_listen_queue  { STRING }? &
+          element tcp_max_per_addr  { STRING }?
+        )
+      }? &
+      element rules { STRING }?
+    )
 }
 
 


### PR DESCRIPTION
trello: https://trello.com/c/HkFkUQHj/1791-3-continue-with-new-xml-parser-xml-validation

depends on yast/yast-autoinstallation#598

Agreed to postpone for now that trang and jing travis validation to not delay even more new xml parser.

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1170886