### PR TITLE
bsc#1196590: set the auto client name in the desktop file

### DIFF
--- a/package/yast2-audit-laf.changes
+++ b/package/yast2-audit-laf.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  3 08:49:34 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Set the name of the auto client in the desktop file
+  (bsc#1196590).
+- 4.3.2
+
+-------------------------------------------------------------------
 Tue Aug 11 12:00:52 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(audit-laf) into the spec file

--- a/package/yast2-audit-laf.spec
+++ b/package/yast2-audit-laf.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-audit-laf
 Summary:        YaST2 - Configuration of Linux Auditing (LAF)
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Url:            https://github.com/yast/yast-audit-laf
 Group:          System/YaST

--- a/src/desktop/org.opensuse.yast.AuditLAF.desktop
+++ b/src/desktop/org.opensuse.yast.AuditLAF.desktop
@@ -13,6 +13,7 @@ X-SuSE-YaST-AutoInst=all
 X-SuSE-YaST-Geometry=
 X-SuSE-YaST-SortKey=
 X-SuSE-YaST-AutoInstClonable=true
+X-SuSE-YaST-AutoInstClient=audit-laf_auto
 X-SuSE-YaST-AutoInstRequires=audit
 X-SuSE-YaST-AutoInstResource=audit-laf
 X-SuSE-YaST-Keywords=audit,auditd,auditctl,auditing,dispatcher,LAF


### PR DESCRIPTION
Fixes [bsc#1196590](https://bugzilla.suse.com/1196590)

It is expected that the client is called `auditlaf_auto` instead of `audit-laf_auto`. We could rename the client, but as the section is called `audit-laf`, I have decided to keep it as it is and set the name in the desktop file.